### PR TITLE
Harden dynamic content rendering and optimize loading

### DIFF
--- a/GoogleSheetRead.html
+++ b/GoogleSheetRead.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>Document</title>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <script id="scriptMain" src="./js/textJSON.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js" defer></script>
+    <script id="scriptMain" src="./js/textJSON.js" defer></script>
 </head>
 
 

--- a/fly.html
+++ b/fly.html
@@ -39,8 +39,10 @@
     <link rel="stylesheet" href="./css/reset.css">
     <link rel="stylesheet" href="./css/main.css">
     <link rel="stylesheet" href="./css/rwd.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <script src="./js/mapMain.js"></script>
+    <link rel="preconnect" href="https://maps.googleapis.com">
+    <link rel="preconnect" href="https://maps.gstatic.com" crossorigin>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js" defer></script>
+    <script src="./js/mapMain.js" defer></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-123979223-1"></script>
     <script>
@@ -115,7 +117,7 @@
         <div id="liliList">
             <a class="lilisSet warpRatio warpImg">
                 <div class="warpCenter">
-                    <img class="liImg" />
+                    <img class="liImg" loading="lazy" decoding="async" alt="LiLi 肖像" />
                 </div>
                 <div class="liTitleSet">
                     <h1 class="liName"></h1>
@@ -134,11 +136,11 @@
             <p class="modeMobile">指導單位・文化部、桃園市議會<br/>主辦單位・桃園市政府<br/>承辦單位・桃園市政府文化局<br/>協力單位・中平路故事館<br/>執行團隊・桃園市社區營造中心<br/>藝術家・張瑋倫、龔芸<br/>張瑋倫 All Right Resereved</p>
             <div class="fb-like" data-share="true" data-width="300px" data-show-faces="true">
             </div>
-            <a class="footerIcon" href="https://zl.tyc.land/LandArtTao"><img src="./img/logoLA.png" /></a>
-            <a class="footerIcon" href="https://zl.tyc.land/fb"><img src="./img/yi.png" /></a>
+            <a class="footerIcon" href="https://zl.tyc.land/LandArtTao"><img src="./img/logoLA.png" loading="lazy" decoding="async" alt="Land Art Tao Logo" /></a>
+            <a class="footerIcon" href="https://zl.tyc.land/fb"><img src="./img/yi.png" loading="lazy" decoding="async" alt="藝遊中壢上河圖" /></a>
         </footer>
     </section>
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyC7xcgFQMcphI_gMTi3OwfF4fuhSFcuOys&callback=initMap" async defer></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyC7xcgFQMcphI_gMTi3OwfF4fuhSFcuOys&callback=initMap" defer></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -39,8 +39,10 @@
     <link rel="stylesheet" href="./css/reset.css">
     <link rel="stylesheet" href="./css/main.css">
     <link rel="stylesheet" href="./css/rwd.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <script src="./js/mapMain.js"></script>
+    <link rel="preconnect" href="https://maps.googleapis.com">
+    <link rel="preconnect" href="https://maps.gstatic.com" crossorigin>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js" defer></script>
+    <script src="./js/mapMain.js" defer></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-123979223-1"></script>
     <script>
@@ -115,7 +117,7 @@
         <div id="liliList">
             <a class="lilisSet warpRatio warpImg">
                 <div class="warpCenter">
-                    <img class="liImg" />
+                    <img class="liImg" loading="lazy" decoding="async" alt="LiLi 肖像" />
                 </div>
                 <div class="liTitleSet">
                     <h1 class="liName"></h1>
@@ -134,11 +136,11 @@
             <p class="modeMobile">指導單位・文化部、桃園市議會<br/>主辦單位・桃園市政府<br/>承辦單位・桃園市政府文化局<br/>協力單位・中平路故事館<br/>執行團隊・桃園市社區營造中心<br/>藝術家・張瑋倫、龔芸<br/>張瑋倫 All Right Resereved</p>
             <div class="fb-like" data-share="true" data-width="300px" data-show-faces="true">
             </div>
-            <a class="footerIcon" href="https://zl.tyc.land/LandArtTao"><img src="./img/logoLA.png" /></a>
-            <a class="footerIcon" href="https://zl.tyc.land/fb"><img src="./img/yi.png" /></a>
+            <a class="footerIcon" href="https://zl.tyc.land/LandArtTao"><img src="./img/logoLA.png" loading="lazy" decoding="async" alt="Land Art Tao Logo" /></a>
+            <a class="footerIcon" href="https://zl.tyc.land/fb"><img src="./img/yi.png" loading="lazy" decoding="async" alt="藝遊中壢上河圖" /></a>
         </footer>
     </section>
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyC7xcgFQMcphI_gMTi3OwfF4fuhSFcuOys&callback=initMap" async defer></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyC7xcgFQMcphI_gMTi3OwfF4fuhSFcuOys&callback=initMap" defer></script>
 </body>
 
 </html>

--- a/js/liMain.js
+++ b/js/liMain.js
@@ -79,6 +79,37 @@ function normalizePhotoRows(photoLog) {
 // === 你原本的變數（保留與路徑一致） ===
 var lilis = [];
 var imglilitype = ['', '../img/icon_blue.png', '../img/icon_lightblue.png', '../img/icon_yellow.png', '../img/icon_red.png', '../img/icon_lime.png'];
+const typeBadges = {
+  1: { icon: './img/mark_1.png', label: '清代時期', link: './index.html?liliType=1' },
+  2: { icon: './img/mark_2.png', label: '日治時期', link: './index.html?liliType=2' },
+  3: { icon: './img/mark_3.png', label: '國民政府來台', link: './index.html?liliType=3' },
+  4: { icon: './img/mark_4.png', label: '城市蓬勃發展', link: './index.html?liliType=4' },
+  5: { icon: './img/mark_5.png', label: '城市多元蛻變', link: './index.html?liliType=5' }
+};
+
+function normalizeYouTubeId(raw) {
+  if (!raw) return '';
+  const value = String(raw).trim();
+  if (/^[A-Za-z0-9_-]{11}$/.test(value)) return value;
+  try {
+    const url = new URL(value, 'https://www.youtube.com');
+    if (url.hostname.includes('youtu.be')) {
+      const id = url.pathname.replace(/^\//, '').slice(0, 11);
+      if (/^[A-Za-z0-9_-]{11}$/.test(id)) return id;
+    }
+    if (url.searchParams.has('v')) {
+      const id = url.searchParams.get('v');
+      if (/^[A-Za-z0-9_-]{11}$/.test(id)) return id;
+    }
+    if (url.pathname.startsWith('/embed/')) {
+      const id = url.pathname.split('/')[2];
+      if (/^[A-Za-z0-9_-]{11}$/.test(id)) return id;
+    }
+  } catch (err) {
+    // ignore parse errors
+  }
+  return '';
+}
 
 // === 主流程 ===
 $.getJSON(
@@ -100,49 +131,80 @@ $.getJSON(
     const aWhere = row.wherecome || '';
     const aWhen = row.whencome || '';
     const aYTLink = row.ytlink || '';
-    const alilitype = Math.max(1, Math.min(5, parseInt(row.lilitype, 10) || 1)); // 1..5
+    const alilitype = Math.max(1, Math.min(5, parseInt(row.lilitype, 10) || 1));
     const aStory = row.story || '';
     const aIntro = row.intro || '';
     const oldPhotoExist = parseInt(row.photoam, 10) || 0;
+    const sanitizedId = encodeURIComponent(String(j));
+    const sanitizedIntro = aIntro.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
 
     // === SEO / OG / 版面填值 ===
-    $("title").append("－No." + j + " LiLi：" + aName);
-    $('meta[itemprop="name"]').attr("content", "LiLi's 我的壢歷史－No." + j + " LiLi：" + aName);
-    $('meta[name="twitter:title"]').attr("content", "LiLi's 我的壢歷史－No." + j + " LiLi：" + aName);
-    $('meta[property="og:title"]').attr("content", "LiLi's 我的壢歷史－No." + j + " LiLi：" + aName);
-    $('meta[property="og:description"]').attr("content", aIntro);
-    $('meta[name="twitter:description"]').attr("content", aIntro);
-    $('meta[name="description"]').attr("content", aIntro);
-    $('meta[itemprop="description"]').attr("content", aIntro);
+    const pageTitle = "LiLi's 我的壢歷史－No." + j + " LiLi：" + aName;
+    document.title = pageTitle;
+    $('meta[itemprop="name"]').attr("content", pageTitle);
+    $('meta[name="twitter:title"]').attr("content", pageTitle);
+    $('meta[property="og:title"]').attr("content", pageTitle);
+    if (sanitizedIntro) {
+      $('meta[property="og:description"]').attr("content", sanitizedIntro);
+      $('meta[name="twitter:description"]').attr("content", sanitizedIntro);
+      $('meta[name="description"]').attr("content", sanitizedIntro);
+      $('meta[itemprop="description"]').attr("content", sanitizedIntro);
+    }
 
     $("#liName").text(aName);
-    var avatarImg = "./img/avatar/" + j + ".png";
-    var avatarImgOG = "https://lili.tyc.land/img/avatar/" + j + ".png";
-    $("#liImg").attr("src", avatarImg);
+    const avatarImg = "./img/avatar/" + sanitizedId + ".png";
+    const avatarImgOG = "https://lili.tyc.land/img/avatar/" + sanitizedId + ".png";
+    $("#liImg").attr({
+      src: avatarImg,
+      alt: aName ? aName + " 的肖像" : "LiLi 肖像",
+      loading: 'lazy',
+      decoding: 'async'
+    });
     $('meta[property="og:image"]').attr("content", avatarImgOG);
     $('meta[name="twitter:image:src"]').attr("content", avatarImgOG);
     $('meta[name="twitter:card"]').attr("content", avatarImgOG);
     $('meta[itemprop="image"]').attr("content", avatarImgOG);
-    $('meta[property="og:url"]').attr("content", "https://lili.tyc.land/lili.html?liliID=" + j);
+    $('meta[property="og:url"]').attr("content", "https://lili.tyc.land/lili.html?liliID=" + sanitizedId);
 
-    $(".tagSet").append(aWhen + " " + aWhere + "<br/>");
-    if (alilitype === 1) $(".tagSet").append("<a href='./index.html?liliType=1'><img src='./img/mark_1.png'/>清代時期</a>");
-    if (alilitype === 2) $(".tagSet").append("<a href='./index.html?liliType=2'><img src='./img/mark_2.png'/>日治時期</a>");
-    if (alilitype === 3) $(".tagSet").append("<a href='./index.html?liliType=3'><img src='./img/mark_3.png'/>國民政府來台</a>");
-    if (alilitype === 4) $(".tagSet").append("<a href='./index.html?liliType=4'><img src='./img/mark_4.png'/>城市蓬勃發展</a>");
-    if (alilitype === 5) $(".tagSet").append("<a href='./index.html?liliType=5'><img src='./img/mark_5.png'/>城市多元蛻變</a>");
+    const $tagSet = $(".tagSet");
+    $tagSet.empty();
+    const infoText = (aWhen + ' ' + aWhere).trim();
+    if (infoText) {
+      $('<span>').text(infoText).appendTo($tagSet);
+      $tagSet.append(document.createElement('br'));
+    }
+    const badge = typeBadges[alilitype];
+    if (badge) {
+      const $link = $('<a>', { href: badge.link });
+      $('<img>', {
+        src: badge.icon,
+        alt: badge.label,
+        loading: 'lazy',
+        decoding: 'async'
+      }).appendTo($link);
+      $link.append(document.createTextNode(badge.label));
+      $tagSet.append($link);
+    }
 
-    // Youtube：若 aYTLink 是純 ID，這樣就 OK；若是完整網址可再補 parse 規則。
-    if (aYTLink) {
-      $("#liliMain iframe.youtube-player").attr("src", "https://www.youtube.com/embed/" + aYTLink);
+    const ytId = normalizeYouTubeId(aYTLink);
+    if (ytId) {
+      $("#liliMain iframe.youtube-player").attr("src", "https://www.youtube.com/embed/" + ytId);
     }
 
     // 內文切段：原本用空白切；若來源其實是以換行分段，也一併支援
+    const $context = $(".aContext");
+    $context.empty();
+    const contextFragment = document.createDocumentFragment();
     const aStorySplit = aStory.indexOf('\n') >= 0 ? aStory.split(/\r?\n/) : aStory.split(' ');
     for (let aSS = 0; aSS < aStorySplit.length; aSS++) {
       const seg = aStorySplit[aSS].trim();
-      if (seg) $(".aContext").append("<p>" + seg + "</p>");
+      if (seg) {
+        const p = document.createElement('p');
+        p.textContent = seg;
+        contextFragment.appendChild(p);
+      }
     }
+    $context.append(contextFragment);
 
     // 舊照片載入（保留你原本的資料夾結構）
     if (oldPhotoExist > 0) {
@@ -152,6 +214,7 @@ $.getJSON(
           const photos = normalizePhotoRows(photoLog);
           let zPhotoAmount = 0;
           const jStr = String(j);
+          const oldPhotoFragment = document.createDocumentFragment();
 
           for (let k = 0; k < photos.length; k++) {
             const pID = String(photos[k].p || '');
@@ -160,16 +223,45 @@ $.getJSON(
               const pEvent = photos[k].event || '';
               const pPoint = photos[k].point || '';
               const pTime  = photos[k].time  || '';
-              const pFileid = photos[k].fileid || '';
-              $("#oldPhoto").append(
-                "<a class='oPhotos' data-lightbox='example-set' data-title='" + pEvent + "・" + pPoint + "・" + pTime +
-                "' href='./img/oldphoto/" + pID + "/" + pFileid + ".jpg'>" +
-                  "<div class='oImg'><img src='./img/oldphoto/" + pID + "/" + pFileid + ".jpg'/></div>" +
-                  "<div class='oContent'>" + pEvent + "<br/><span class='pWid'>" + pPoint + "・" + pTime + "</span></div>" +
-                "</a>"
-              );
+              const pFileidRaw = photos[k].fileid || '';
+              const safeFolder = encodeURIComponent(pID);
+              const safeFile = encodeURIComponent(pFileidRaw);
+              const captionParts = [pEvent, pPoint, pTime].filter(Boolean);
+              const caption = captionParts.join('・');
+
+              const link = document.createElement('a');
+              link.className = 'oPhotos';
+              link.dataset.lightbox = 'example-set';
+              link.dataset.title = caption;
+              link.href = `./img/oldphoto/${safeFolder}/${safeFile}.jpg`;
+              if (caption) {
+                link.setAttribute('aria-label', caption);
+              }
+
+              const imgWrapper = document.createElement('div');
+              imgWrapper.className = 'oImg';
+              const img = document.createElement('img');
+              img.src = `./img/oldphoto/${safeFolder}/${safeFile}.jpg`;
+              img.alt = caption || '老照片';
+              img.loading = 'lazy';
+              img.decoding = 'async';
+              imgWrapper.appendChild(img);
+
+              const contentWrapper = document.createElement('div');
+              contentWrapper.className = 'oContent';
+              contentWrapper.appendChild(document.createTextNode(pEvent));
+              contentWrapper.appendChild(document.createElement('br'));
+              const span = document.createElement('span');
+              span.className = 'pWid';
+              span.textContent = [pPoint, pTime].filter(Boolean).join('・');
+              contentWrapper.appendChild(span);
+
+              link.appendChild(imgWrapper);
+              link.appendChild(contentWrapper);
+              oldPhotoFragment.appendChild(link);
             }
           }
+          $("#oldPhoto").empty().append(oldPhotoFragment);
           console.log('已載入舊照數：', zPhotoAmount, '（預期：', oldPhotoExist, '）');
         }
       ).fail(function (jqxhr, textStatus, error) {

--- a/js/mapMain.js
+++ b/js/mapMain.js
@@ -57,6 +57,19 @@ var filterSwitch = [1, 1, 1, 1, 1, 1];
 // === 主程式 ===
 function initMap() {
   const imglilitype = ['', './img/icon_blue.png', './img/icon_lightblue.png', './img/icon_yellow.png', './img/icon_red.png', './img/icon_lime.png'];
+  const typeBadges = {
+    1: { icon: "./img/mark_1.png", label: "清國時期" },
+    2: { icon: "./img/mark_2.png", label: "日治時期" },
+    3: { icon: "./img/mark_3.png", label: "國民政府來台" },
+    4: { icon: "./img/mark_4.png", label: "城市蓬勃發展" },
+    5: { icon: "./img/mark_5.png", label: "城市多元蛻變" }
+  };
+
+  const listEl = document.getElementById('liliList');
+  const listTemplate = listEl?.querySelector('.lilisSet')?.cloneNode(true) || null;
+  if (listEl) {
+    listEl.textContent = '';
+  }
 
   // 1) 先建立地圖（避免資料 callback 超車）
   const map = new google.maps.Map(document.getElementById('map'), {
@@ -94,6 +107,8 @@ function initMap() {
       const rows = normalizeRows(dataLog);
       console.log('筆數：', rows.length);
 
+      const listFragment = document.createDocumentFragment();
+
       for (let i = 0; i < rows.length; i++) {
         const row = rows[i];
 
@@ -105,30 +120,60 @@ function initMap() {
         const alilitypeNum = Math.max(1, Math.min(5, parseInt(row.lilitype, 10) || 1));
         const aWhere = row.wherecome || '';
         const aWhen = row.whencome || '';
-        const avatarImg = "./img/avatar/" + (i + 1) + ".png";
+        const sanitizedId = encodeURIComponent(aZ);
 
         // 無座標就跳過
         if (!isFinite(aLatitude) || !isFinite(aLongtitude)) continue;
 
         // 右側清單：若有篩選參數，就只顯示該類
         if (ltypeParam === null || String(alilitypeNum) === ltypeParam) {
-          if ($(".lilisSet").length > 0) {
-            $(".lilisSet:first").clone().appendTo("#liliList");
-            $(".lilisSet:last").attr("href", "./lili.html?liliID=" + aZ);
-            $(".lilisSet:last .liName").text(aName);
-            $(".lilisSet:last .liImg").attr("src", avatarImg);
-            $(".lilisSet:last .tagSet").html(aWhen + "  " + aWhere + "<br/>");
-            if (alilitypeNum === 1) $(".lilisSet:last .tagSet").append("<img src='./img/mark_1.png'/>清國時期");
-            if (alilitypeNum === 2) $(".lilisSet:last .tagSet").append("<img src='./img/mark_2.png'/>日本時期");
-            if (alilitypeNum === 3) $(".lilisSet:last .tagSet").append("<img src='./img/mark_3.png'/>國民政府來台");
-            if (alilitypeNum === 4) $(".lilisSet:last .tagSet").append("<img src='./img/mark_4.png'/>城市蓬勃發展");
-            if (alilitypeNum === 5) $(".lilisSet:last .tagSet").append("<img src='./img/mark_5.png'/>城市多元蛻變");
+          if (listEl && listTemplate) {
+            const item = listTemplate.cloneNode(true);
+            item.setAttribute('href', './lili.html?liliID=' + sanitizedId);
+
+            const nameEl = item.querySelector('.liName');
+            if (nameEl) nameEl.textContent = aName;
+
+            const imgEl = item.querySelector('.liImg');
+            if (imgEl) {
+              imgEl.setAttribute('src', './img/avatar/' + sanitizedId + '.png');
+              imgEl.setAttribute('alt', aName ? aName + ' 的肖像' : 'LiLi 肖像');
+              imgEl.setAttribute('loading', 'lazy');
+              imgEl.setAttribute('decoding', 'async');
+            }
+
+            const tagSetEl = item.querySelector('.tagSet');
+            if (tagSetEl) {
+              tagSetEl.textContent = '';
+              const infoText = (aWhen + ' ' + aWhere).trim();
+              if (infoText) {
+                const infoSpan = document.createElement('span');
+                infoSpan.textContent = infoText;
+                tagSetEl.appendChild(infoSpan);
+                tagSetEl.appendChild(document.createElement('br'));
+              }
+
+              const badge = typeBadges[alilitypeNum];
+              if (badge) {
+                const badgeWrapper = document.createElement('span');
+                const badgeImg = document.createElement('img');
+                badgeImg.src = badge.icon;
+                badgeImg.alt = badge.label;
+                badgeImg.loading = 'lazy';
+                badgeImg.decoding = 'async';
+                badgeWrapper.appendChild(badgeImg);
+                badgeWrapper.appendChild(document.createTextNode(badge.label));
+                tagSetEl.appendChild(badgeWrapper);
+              }
+            }
+
+            listFragment.appendChild(item);
           }
         }
 
         // 底層圖標
         const marker = new google.maps.Marker({
-          url: './lili.html?liliID=' + aZ,
+          url: './lili.html?liliID=' + sanitizedId,
           position: { lat: aLatitude, lng: aLongtitude },
           map,
           title: aName,
@@ -140,12 +185,12 @@ function initMap() {
 
         // 頂層頭像
         const markerTop = new google.maps.Marker({
-          url: './lili.html?liliID=' + aZ,
+          url: './lili.html?liliID=' + sanitizedId,
           position: { lat: aLatitude, lng: aLongtitude },
           map,
           title: aName,
           icon: {
-            url: './img/avatar_circle/' + aZ + '.png',
+            url: './img/avatar_circle/' + sanitizedId + '.png',
             scaledSize: new google.maps.Size(52, 52),
             anchor: new google.maps.Point(26, 95),
           }
@@ -156,16 +201,15 @@ function initMap() {
         gmarkers.push(marker);
         markersTop.push(alilitypeNum);
         gmarkersTop.push(markerTop);
-        markersUrl.push(aZ);
-        markersUrlTop.push(aZ);
+        markersUrl.push(sanitizedId);
+        markersUrlTop.push(sanitizedId);
 
         marker.addListener('click', function () { location.href = this.url; });
         markerTop.addListener('click', function () { location.href = this.url; });
       }
 
-      // 移除模板那一筆
-      if (rows.length > 0 && $(".lilisSet").length > 0) {
-        $(".lilisSet:first").remove();
+      if (listEl && listFragment.childNodes.length > 0) {
+        listEl.appendChild(listFragment);
       }
 
       checkLiliType();

--- a/js/textJSON.js
+++ b/js/textJSON.js
@@ -1,19 +1,43 @@
- $(document).ready(function () {
-     $(function () {
-         var aLatitude = [];
-         var aLongtitude = [];
-         var dataAmount = 0;
-         console.log("w");
-         $.getJSON('https://script.google.com/macros/s/AKfycbxscTjzWn9YTZ_Vmrrs-mB_DQZDrORmzlXdQrgL-2YxKkVYq9js4WlzM5zIAg8PYjPjVQ/exec', function (dataLog) {
-                 console.log("gJson");
-                 dataAmount = dataLog.feed.entry.length;
-                 console.log(dataAmount);
-                 for (var i = 0; i < dataAmount; i++) {
-                     aLatitude[i] = dataLog.feed.entry[i].gsx$lati.$t;
-                     aLongtitude[i] = dataLog.feed.entry[i].gsx$longi.$t;
-                     $('#ext').append("<br>" + aLatitude[i] + "," + aLongtitude[i]);
-                 } //end for
-             } //end function data
-         ); //end get JSON
-     }); //end function
- });
+$(function () {
+  function normalizeRows(dataLog) {
+    if (dataLog && dataLog.feed && Array.isArray(dataLog.feed.entry)) {
+      return dataLog.feed.entry.map((entry) => ({
+        lat: entry['gsx$lati']?.$t ?? '',
+        lng: entry['gsx$longi']?.$t ?? ''
+      }));
+    }
+    const candidate =
+      Array.isArray(dataLog) ? dataLog :
+      dataLog?.data || dataLog?.records || dataLog?.rows || dataLog?.items || [];
+    if (Array.isArray(candidate)) {
+      return candidate.map((entry) => ({
+        lat: entry.lati ?? entry.lat ?? '',
+        lng: entry.longi ?? entry.lng ?? entry.lon ?? ''
+      }));
+    }
+    console.warn('無法辨識的座標資料格式：', dataLog);
+    return [];
+  }
+
+  $.getJSON(
+    'https://script.google.com/macros/s/AKfycbxscTjzWn9YTZ_Vmrrs-mB_DQZDrORmzlXdQrgL-2YxKkVYq9js4WlzM5zIAg8PYjPjVQ/exec',
+    function (dataLog) {
+      const rows = normalizeRows(dataLog);
+      const extEl = document.getElementById('ext');
+      if (!extEl) return;
+      extEl.textContent = '';
+      const fragment = document.createDocumentFragment();
+      rows.forEach((row) => {
+        const lat = String(row.lat || '').trim();
+        const lng = String(row.lng || '').trim();
+        if (!lat || !lng) return;
+        const line = document.createElement('div');
+        line.textContent = lat + ',' + lng;
+        fragment.appendChild(line);
+      });
+      extEl.appendChild(fragment);
+    }
+  ).fail(function (jqxhr, textStatus, error) {
+    console.error('讀取座標資料失敗：', textStatus, error);
+  });
+});

--- a/js/yi.js
+++ b/js/yi.js
@@ -1,50 +1,137 @@
-function GetURLParameter(sParam) {
-    var sPageURL = window.location.search.substring(1);
-    var sURLVariables = sPageURL.split('&');
-    for (var i = 0; i < sURLVariables.length; i++) {
-        var sParameterName = sURLVariables[i].split('=');
-        if (sParameterName[0] == sParam) {
-            return sParameterName[1];
-        }
+// === utils ===
+function getQueryParam(name) {
+  const params = new URLSearchParams(window.location.search);
+  const value = params.get(name);
+  return value ? decodeURIComponent(value) : null;
+}
+
+function normalizeRows(dataLog) {
+  if (dataLog && dataLog.feed && Array.isArray(dataLog.feed.entry)) {
+    return dataLog.feed.entry.map((entry) => ({
+      nameTw: entry['gsx$nametw']?.$t ?? '',
+      nameEng: entry['gsx$nameeng']?.$t ?? '',
+      community: entry['gsx$community']?.$t ?? '',
+      ytlink: entry['gsx$ytlink']?.$t ?? '',
+      nationTw: entry['gsx$nationtw']?.$t ?? '',
+      nationEng: entry['gsx$nationeng']?.$t ?? ''
+    }));
+  }
+
+  const candidate =
+    Array.isArray(dataLog) ? dataLog :
+    dataLog?.data || dataLog?.records || dataLog?.rows || dataLog?.items || [];
+
+  if (Array.isArray(candidate)) {
+    return candidate.map((entry) => ({
+      nameTw: entry.nametw ?? entry.name_tw ?? entry.name ?? '',
+      nameEng: entry.nameeng ?? entry.name_eng ?? entry.english ?? '',
+      community: entry.community ?? entry.summary ?? '',
+      ytlink: entry.ytlink ?? entry.youtube ?? '',
+      nationTw: entry.nationtw ?? entry.nation_tw ?? '',
+      nationEng: entry.nationeng ?? entry.nation_eng ?? ''
+    }));
+  }
+
+  console.warn('無法辨識的藝術家資料格式：', dataLog);
+  return [];
+}
+
+function normalizeYouTubeId(raw) {
+  if (!raw) return '';
+  const value = String(raw).trim();
+  if (/^[A-Za-z0-9_-]{11}$/.test(value)) return value;
+  try {
+    const url = new URL(value, 'https://www.youtube.com');
+    if (url.hostname.includes('youtu.be')) {
+      const id = url.pathname.replace(/^\//, '').slice(0, 11);
+      if (/^[A-Za-z0-9_-]{11}$/.test(id)) return id;
     }
-};
+    if (url.searchParams.has('v')) {
+      const id = url.searchParams.get('v');
+      if (/^[A-Za-z0-9_-]{11}$/.test(id)) return id;
+    }
+    if (url.pathname.startsWith('/embed/')) {
+      const id = url.pathname.split('/')[2];
+      if (/^[A-Za-z0-9_-]{11}$/.test(id)) return id;
+    }
+  } catch (err) {
+    // ignore parse errors
+  }
+  return '';
+}
 
-var lilis = [];
-var imglilitype = ['', '../img/icon_blue.png', '../img/icon_lightblue.png', '../img/icon_yellow.png', '../img/icon_red.png', '../img/icon_lime.png'];
-$.getJSON('https://script.google.com/macros/s/AKfycbxscTjzWn9YTZ_Vmrrs-mB_DQZDrORmzlXdQrgL-2YxKkVYq9js4WlzM5zIAg8PYjPjVQ/exec', function (dataLog) {
+// === 主流程 ===
+$.getJSON(
+  'https://script.google.com/macros/s/AKfycbxscTjzWn9YTZ_Vmrrs-mB_DQZDrORmzlXdQrgL-2YxKkVYq9js4WlzM5zIAg8PYjPjVQ/exec',
+  function (dataLog) {
+    const rows = normalizeRows(dataLog);
+    if (!rows.length) {
+      console.warn('藝術家資料為空');
+      return;
+    }
 
-        //        console.log("gJson");
-        var i = GetURLParameter("artist") - 1;
-        var j = GetURLParameter("artist");
-        //        console.log(i);
-        if (j == null) {
-            i = Math.floor(Math.random() * (14 - 1));
-            j = i + 1;
-        }
-        var aNameTw = dataLog.feed.entry[i].gsx$nametw.$t;
-        var aNameEng = dataLog.feed.entry[i].gsx$nameeng.$t;
-        var aCommunity = dataLog.feed.entry[i].gsx$community.$t;
-        var aYTLink = dataLog.feed.entry[i].gsx$ytlink.$t;
-        var aNationTw = dataLog.feed.entry[i].gsx$nationtw.$t;
-        var aNationEng = dataLog.feed.entry[i].gsx$nationeng.$t;
+    const paramValue = getQueryParam('artist');
+    let index = Number.parseInt(paramValue, 10);
+    if (Number.isNaN(index) || index < 1 || index > rows.length) {
+      index = Math.floor(Math.random() * rows.length) + 1;
+    }
+    const arrayIndex = index - 1;
 
+    const row = rows[arrayIndex] || {};
+    const nameTw = row.nameTw || '';
+    const nameEng = row.nameEng || '';
+    const community = row.community || '';
+    const ytlink = row.ytlink || '';
+    const nationTw = row.nationTw || '';
+    const nationEng = row.nationEng || '';
+    const sanitizedId = encodeURIComponent(String(index));
 
-        $("title").append(aNameTw + "・" + aNameEng);
-        $('meta[itemprop="name"]').attr("content", "藝遊中壢上河圖 - 藝術家／" + aNameTw + "・" + aNameEng);
-        $('meta[name="twitter:title"]').attr("content", "藝遊中壢上河圖 - 藝術家／" + aNameTw + "・" + aNameEng);
-        $('meta[property="og:title"]').attr("content", "藝遊中壢上河圖 - 藝術家／" + aNameTw + "・" + aNameEng);
+    const pageTitle = `藝遊中壢上河圖 - 藝術家／${nameTw}・${nameEng}`;
+    document.title = pageTitle;
+    $('meta[itemprop="name"]').attr('content', pageTitle);
+    $('meta[name="twitter:title"]').attr('content', pageTitle);
+    $('meta[property="og:title"]').attr('content', pageTitle);
+    $('meta[property="og:url"]').attr('content', 'https://lili.tyc.land/y.html?artist=' + sanitizedId);
 
-        $("#liName").append(aNameTw + "<br>" + aNameEng);
+    const $liName = $('#liName');
+    $liName.empty();
+    if (nameTw) {
+      $('<span>').text(nameTw).appendTo($liName);
+    }
+    if (nameEng) {
+      if (nameTw) $liName.append(document.createElement('br'));
+      $('<span>').text(nameEng).appendTo($liName);
+    }
 
-        $(".tagSet").append(aNationTw + "<br>" + aNationEng)
-        $('meta[property="og:url"]').attr("content", "https://lili.tyc.land/y.html?artist=" + j);
+    const $tagSet = $('.tagSet');
+    $tagSet.empty();
+    if (nationTw) {
+      $('<span>').text(nationTw).appendTo($tagSet);
+      $tagSet.append(document.createElement('br'));
+    }
+    if (nationEng) {
+      $('<span>').text(nationEng).appendTo($tagSet);
+    }
 
-        $("#liliMain iframe.youtube-player").attr("src", "https://www.youtube.com/embed/" + aYTLink);
-        var aStorySplit = aCommunity.split(" ");
-        for (var aSS = 0; aSS < aStorySplit.length; aSS++) {
-            $(".aContext").append("<p>" + aStorySplit[aSS] + "</p>");
-        }
+    const ytId = normalizeYouTubeId(ytlink);
+    if (ytId) {
+      $('#liliMain iframe.youtube-player').attr('src', 'https://www.youtube.com/embed/' + ytId);
+    }
 
-
-    } //end function data
-); //end get JSON
+    const $context = $('.aContext');
+    $context.find('p').remove();
+    const fragment = document.createDocumentFragment();
+    const communityParts = community.indexOf('\n') >= 0 ? community.split(/\r?\n/) : community.split(/\s+/);
+    communityParts.forEach((part) => {
+      const text = part.trim();
+      if (text) {
+        const p = document.createElement('p');
+        p.textContent = text;
+        fragment.appendChild(p);
+      }
+    });
+    $context.append(fragment);
+  }
+).fail(function (jqxhr, textStatus, error) {
+  console.error('讀取藝術家資料失敗：', textStatus, error);
+});

--- a/lili.html
+++ b/lili.html
@@ -40,9 +40,9 @@
     <link rel="stylesheet" href="./css/main.css">
     <link rel="stylesheet" href="./css/rwd.css">
     <link rel="stylesheet" href="./css/lightbox.min.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <script src="./js/liMain.js"></script>
-    <script src="./js/lightbox.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js" defer></script>
+    <script src="./js/liMain.js" defer></script>
+    <script src="./js/lightbox.min.js" defer></script>
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-123979223-1"></script>
@@ -118,7 +118,7 @@
             </div>
             <div class="warpRatio warpImg">
                 <div class="warpCenter">
-                    <img id="liImg" />
+                    <img id="liImg" loading="lazy" decoding="async" alt="LiLi 肖像" />
                 </div>
             </div>
             <div class="aContext">
@@ -133,19 +133,22 @@
             <p class="modeWeb">指導單位・文化部、桃園市議會｜主辦單位・桃園市政府｜承辦單位・桃園市政府文化局<br/>協力單位・中平路故事館｜執行團隊・桃園市社區營造中心<br/>藝術家・張瑋倫、龔芸｜張瑋倫 All Right Resereved</p>
 
             <p class="modeMobile">指導單位・文化部、桃園市議會<br/>主辦單位・桃園市政府<br/>承辦單位・桃園市政府文化局<br/>協力單位・中平路故事館<br/>執行團隊・桃園市社區營造中心<br/>藝術家・張瑋倫、龔芸<br/>張瑋倫 All Right Resereved</p>
-            <a class="footerIcon" href="https://zl.tyc.land/LandArtTao"><img src="./img/logoLA.png" /></a>
-            <a class="footerIcon" href="https://zl.tyc.land/fb"><img src="./img/yi.png" /></a>
+            <a class="footerIcon" href="https://zl.tyc.land/LandArtTao"><img src="./img/logoLA.png" loading="lazy" decoding="async" alt="Land Art Tao Logo" /></a>
+            <a class="footerIcon" href="https://zl.tyc.land/fb"><img src="./img/yi.png" loading="lazy" decoding="async" alt="藝遊中壢上河圖" /></a>
 
         </footer>
     </section>
     <script>
-        lightbox.option({
-            'resizeDuration': 200,
-            'wrapAround': true,
-            'albumLabel': "老照片 %1 / %2",
-            'alwaysShowNavOnTouchDevices': true
-        })
-
+        document.addEventListener('DOMContentLoaded', function () {
+            if (window.lightbox && typeof window.lightbox.option === 'function') {
+                lightbox.option({
+                    'resizeDuration': 200,
+                    'wrapAround': true,
+                    'albumLabel': "老照片 %1 / %2",
+                    'alwaysShowNavOnTouchDevices': true
+                });
+            }
+        });
     </script>
 </body>
 

--- a/y.html
+++ b/y.html
@@ -40,8 +40,8 @@
     <link rel="stylesheet" href="./css/main.css">
     <link rel="stylesheet" href="./css/rwd.css">
     <link rel="stylesheet" href="./css/yi.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <script src="./js/yi.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js" defer></script>
+    <script src="./js/yi.js" defer></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-123979223-1"></script>
     <script>
@@ -143,8 +143,8 @@
             <p class="modeWeb">指導單位・文化部、桃園市議會｜主辦單位・桃園市政府｜承辦單位・桃園市政府文化局<br/>執行團隊・桃園市社區營造中心</p>
 
             <p class="modeMobile">指導單位・文化部、桃園市議會<br/>主辦單位・桃園市政府<br/>承辦單位・桃園市政府文化局<br/>執行團隊・桃園市社區營造中心</p>
-            <a class="footerIcon" href="https://zl.tyc.land/LandArtTao"><img src="./img/logoLA.png" /></a>
-            <a class="footerIcon" href="https://zl.tyc.land/fb"><img src="./img/yi.png" /></a>
+            <a class="footerIcon" href="https://zl.tyc.land/LandArtTao"><img src="./img/logoLA.png" loading="lazy" decoding="async" alt="Land Art Tao Logo" /></a>
+            <a class="footerIcon" href="https://zl.tyc.land/fb"><img src="./img/yi.png" loading="lazy" decoding="async" alt="藝遊中壢上河圖" /></a>
 
         </footer>
     </section>


### PR DESCRIPTION
## Summary
- sanitize all Google Sheet driven rendering on the map, profile, and artist pages to prevent unescaped HTML from reaching the DOM and add stricter query/id handling
- harden old photo gallery and coordinate helpers while normalizing YouTube IDs for safe embeds
- upgrade frontend plumbing to jQuery 3.7.1, defer local scripts, add Google Maps preconnects, and enable lazy-loading imagery for faster first paint

## Testing
- node --check js/mapMain.js
- node --check js/liMain.js
- node --check js/yi.js
- node --check js/textJSON.js


------
https://chatgpt.com/codex/tasks/task_e_68f9f678070c8324814d407869afa0c2